### PR TITLE
Removing `insert'`, `lookup'` and `delete'` in favor of non-primed versions

### DIFF
--- a/AVL.cabal
+++ b/AVL.cabal
@@ -90,6 +90,7 @@ test-suite avl-tree-sanity
                      , AVL
                      , binary
                      , bytestring
+                     , containers
                      , data-default
                      , exceptions
                      , hashable

--- a/AVL.cabal
+++ b/AVL.cabal
@@ -38,6 +38,7 @@ library
                      , mtl
                      , stm
                      , unordered-containers
+                     , zipp
   default-extensions:
                AllowAmbiguousTypes
                ConstraintKinds

--- a/src/Data/Tree/AVL.hs
+++ b/src/Data/Tree/AVL.hs
@@ -113,7 +113,7 @@ module Data.Tree.AVL
       -- * Operations over AVL+
     , insert, insertWithNoProof
     , delete, deleteWithNoProof
-    , lookup
+    , lookup, lookupMany
     , fold
     , foldIf
 

--- a/src/Data/Tree/AVL/Deletion.hs
+++ b/src/Data/Tree/AVL/Deletion.hs
@@ -44,10 +44,10 @@ deleteZ k = withLocus $ \case
     MLLeaf { _mlKey } ->
         if _mlKey == k
         then True  <$ replaceWith (empty :: Map h k v)
-        else False <$ mark "deleteZ/node exists"
+        else False <$ markHere
 
     MLEmpty {} ->
-        False <$ mark "deleteZ/empty"
+        False <$ markHere
 
     MLBranch {} -> do
         goto (Plain k)

--- a/src/Data/Tree/AVL/Deletion.hs
+++ b/src/Data/Tree/AVL/Deletion.hs
@@ -16,17 +16,13 @@ import Data.Tree.AVL.Zipper
 
 -- | Remove given key from the 'Map', generates raw proof.
 delete :: Retrieves h k v m => k -> Map h k v -> m (Set h, Map h k v)
-delete k tree = do
-    (_yes, res, trails) <- runZipped (deleteZ k) DeleteMode tree
-    return (trails, res)
+delete k tree = execZipped DeleteMode tree $ deleteZ k
 
 -- | Remove given key from the 'Map', generates baked proof.
 --
 --   It is idempotent.
 delete' :: Retrieves h k v m => k -> Map h k v -> m (Proof h k v, Map h k v)
-delete' k tree = do
-    (_yes, res, proof) <- runZipped' (deleteZ k) DeleteMode tree
-    return (proof, res)
+delete' k tree = execZipped' DeleteMode tree $ deleteZ k
 
 -- | Remove given key from the 'Map', with no proof.
 deleteWithNoProof
@@ -35,7 +31,7 @@ deleteWithNoProof
     -> Map h k v
     -> m (Map h k v)
 deleteWithNoProof k tree = do
-    (_yes, res, _proof) <- runZipped (deleteZ k) DeleteMode tree
+    (_, res) <- execZipped DeleteMode tree $ deleteZ k
     return res
 
 -- | Deletion algorithm.

--- a/src/Data/Tree/AVL/Deletion.hs
+++ b/src/Data/Tree/AVL/Deletion.hs
@@ -5,38 +5,21 @@
 module Data.Tree.AVL.Deletion
     ( delete
     , deleteWithNoProof
-    , delete'
     ) where
 
 import Data.Set (Set)
 
 import Data.Tree.AVL.Internal
-import Data.Tree.AVL.Proof
 import Data.Tree.AVL.Zipper
 
--- | Remove given key from the 'Map', generates raw proof.
-delete :: Retrieves h k v m => k -> Map h k v -> m (Set h, Map h k v)
-delete k tree = execZipped DeleteMode tree $ deleteZ k
+deleteWithNoProof :: Retrieves h k v m => k -> Map h k v -> m (Map h k v)
+deleteWithNoProof k tree = snd <$> delete k tree
 
--- | Remove given key from the 'Map', generates baked proof.
+-- | Remove given key from the 'Map', generates raw proof.
 --
 --   It is idempotent.
-delete' :: Retrieves h k v m => k -> Map h k v -> m (Proof h k v, Map h k v)
-delete' k tree = execZipped' DeleteMode tree $ deleteZ k
-
--- | Remove given key from the 'Map', with no proof.
-deleteWithNoProof
-    :: Retrieves h k v m
-    => k
-    -> Map h k v
-    -> m (Map h k v)
-deleteWithNoProof k tree = do
-    (_, res) <- execZipped DeleteMode tree $ deleteZ k
-    return res
-
--- | Deletion algorithm.
-deleteZ :: forall h k v m . Retrieves h k v m => k -> Zipped h k v m Bool
-deleteZ k = withLocus $ \case
+delete :: forall h k v m . Retrieves h k v m => k -> Map h k v -> m (Set h, Map h k v)
+delete k tree = execZipped DeleteMode tree $ withLocus $ \case
     MLLeaf { _mlKey } ->
         if _mlKey == k
         then True  <$ replaceWith (empty :: Map h k v)

--- a/src/Data/Tree/AVL/Insertion.hs
+++ b/src/Data/Tree/AVL/Insertion.hs
@@ -28,17 +28,13 @@ import Data.Tree.AVL.Zipper
 --   It is idempotent in terms of 'Map' content, however, without 'Eq' @k@
 --   constraint 'Map's will be different.
 insert :: Retrieves h k v m => k -> v -> Map h k v -> m (Set h, Map h k v)
-insert k v tree = do
-    ((), res, trails) <- runZipped (insertZ k v) UpdateMode tree
-    return (trails, res)
+insert k v tree = execZipped UpdateMode tree $ insertZ k v
 
 -- | Inserts given value for given key into the 'Map', generates baked proof.
 --
 --   See 'insert''.
 insert' :: Retrieves h k v m => k -> v -> Map h k v -> m (Proof h k v, Map h k v)
-insert' k v tree = do
-    ((), res, proof) <- runZipped' (insertZ k v) UpdateMode tree
-    return (proof, res)
+insert' k v tree = execZipped' UpdateMode tree $ insertZ k v
 
 -- | Just inserts given value for given key into the 'Map', with no proof.
 --
@@ -50,7 +46,7 @@ insertWithNoProof
     -> Map h k v
     -> m (Map h k v)
 insertWithNoProof k v tree = do
-    ((), res, _) <- runZipped (insertZ k v) UpdateMode tree
+    (_, res) <- execZipped UpdateMode tree $ insertZ k v
     return res
 
 -- | Insertion algorithm.

--- a/src/Data/Tree/AVL/Internal.hs
+++ b/src/Data/Tree/AVL/Internal.hs
@@ -53,6 +53,7 @@ module Data.Tree.AVL.Internal
     , load
     , loadAnd
     , loadAndM
+    , close
 
       -- * Low-level access
     , pattern Node

--- a/src/Data/Tree/AVL/Internal.hs
+++ b/src/Data/Tree/AVL/Internal.hs
@@ -53,7 +53,6 @@ module Data.Tree.AVL.Internal
     , load
     , loadAnd
     , loadAndM
-    , close
 
       -- * Low-level access
     , pattern Node

--- a/src/Data/Tree/AVL/Iteration.hs
+++ b/src/Data/Tree/AVL/Iteration.hs
@@ -32,8 +32,9 @@ walkDFS (start, add, finish) root = runWriterT $ finish <$> go start root
                 MLBranch { _mlLeft = l, _mlRight = r } -> do
                   acc' <- go (add point' acc) l
                   go acc' r
-                MLLeaf  {} -> return $ add point' acc
-                MLEmpty {} -> return acc
+                
+                _ -> do
+                  return $ add point' acc
 
 -- | Left-to-right fold.
 foldIf

--- a/src/Data/Tree/AVL/Lookup.hs
+++ b/src/Data/Tree/AVL/Lookup.hs
@@ -17,13 +17,13 @@ import Data.Tree.AVL.Zipper
 -- | Retrieves value for given key. Also collects raw proof.
 lookup :: Retrieves h k v m => k -> Map h k v -> m ((Maybe v, Set h), Map h k v)
 lookup k tree0 = do
-    (mv, tree, trails) <- runZipped (lookupZ k) UpdateMode tree0
+    (mv, tree, trails) <- runZipped UpdateMode tree0 $ lookupZ k
     return ((mv, trails), tree)
 
 -- | Retrieves value for given key. Also constructs baked proof.
 lookup' :: Retrieves h k v m => k -> Map h k v -> m ((Maybe v, Proof h k v), Map h k v)
 lookup' k tree0 = do
-    (mv, tree, proof) <- runZipped' (lookupZ k) UpdateMode tree0
+    (mv, tree, proof) <- runZipped' UpdateMode tree0 $ lookupZ k
     return ((mv, proof), tree)
 
 -- | The implementation of lookup.
@@ -31,7 +31,22 @@ lookupZ :: Retrieves h k v m => k -> Zipped h k v m (Maybe v)
 lookupZ k = do
     goto (Plain k)
     withLocus $ \case
-        MLLeaf {_mlKey, _mlValue} ->
-            return $ if _mlKey == k then Just _mlValue else Nothing
-        MLEmpty {} -> return Nothing
-        _ -> error $ "lookup: `goto ended in non-terminal node"
+        MLLeaf {_mlKey, _mlValue} -> do
+            if   _mlKey == k
+            then do
+                gotoNextKey k
+                gotoPrevKey k
+
+                return $ Just _mlValue
+            else do
+                if _mlKey > k
+                then gotoPrevKey k
+                else gotoNextKey k
+
+                return Nothing
+        
+        MLEmpty {} -> do
+            return Nothing
+        
+        _ -> do 
+            error $ "lookup: `goto ended in non-terminal node"

--- a/src/Data/Tree/AVL/Lookup.hs
+++ b/src/Data/Tree/AVL/Lookup.hs
@@ -5,16 +5,32 @@
 module Data.Tree.AVL.Lookup
     ( -- * Lookups
       Data.Tree.AVL.Lookup.lookup
+    , lookupMany
     ) where
 
+import Data.Traversable (for)
 import Data.Set (Set)
+import qualified Data.Set as Set (toList)
+import qualified Data.Map as BinTree (Map, empty, singleton, unions)
 
 import Data.Tree.AVL.Internal
 import Data.Tree.AVL.Zipper
 
 -- | Retrieves value for given key. Also collects raw proof.
 lookup :: Retrieves h k v m => k -> Map h k v -> m ((Maybe v, Set h), Map h k v)
-lookup k tree0 = (assoc <$>) $ runZipped UpdateMode tree0 $ do
+lookup k tree0 = assoc <$> runZipped UpdateMode tree0 (lookupZ k)
+
+-- | Retrieves value for given key. Also collects raw proof.
+lookupMany :: Retrieves h k v m => Set k -> Map h k v -> m ((BinTree.Map k v, Set h), Map h k v)
+lookupMany ks tree0 = (assoc <$>) $ runZipped UpdateMode tree0 $ do
+    pairs <- for (Set.toList ks) $ \k -> do
+        maybe BinTree.empty (BinTree.singleton k)
+            <$> lookupZ k
+
+    return $ BinTree.unions pairs
+
+lookupZ :: Retrieves h k v m => k -> Zipped h k v m (Maybe v)
+lookupZ k = do
     goto (Plain k)
     withLocus $ \case
         MLLeaf {_mlKey, _mlValue} -> do
@@ -36,5 +52,6 @@ lookup k tree0 = (assoc <$>) $ runZipped UpdateMode tree0 $ do
         
         _ -> do 
             error $ "lookup: `goto ended in non-terminal node"
-  where
-    assoc (mv, tree, trails) = ((mv, trails), tree)
+
+assoc :: (a, b, c) -> ((a, c), b)
+assoc (mv, tree, trails) = ((mv, trails), tree)

--- a/src/Data/Tree/AVL/Lookup.hs
+++ b/src/Data/Tree/AVL/Lookup.hs
@@ -5,30 +5,16 @@
 module Data.Tree.AVL.Lookup
     ( -- * Lookups
       Data.Tree.AVL.Lookup.lookup
-    , lookup'
     ) where
 
 import Data.Set (Set)
 
 import Data.Tree.AVL.Internal
-import Data.Tree.AVL.Proof
 import Data.Tree.AVL.Zipper
 
 -- | Retrieves value for given key. Also collects raw proof.
 lookup :: Retrieves h k v m => k -> Map h k v -> m ((Maybe v, Set h), Map h k v)
-lookup k tree0 = do
-    (mv, tree, trails) <- runZipped UpdateMode tree0 $ lookupZ k
-    return ((mv, trails), tree)
-
--- | Retrieves value for given key. Also constructs baked proof.
-lookup' :: Retrieves h k v m => k -> Map h k v -> m ((Maybe v, Proof h k v), Map h k v)
-lookup' k tree0 = do
-    (mv, tree, proof) <- runZipped' UpdateMode tree0 $ lookupZ k
-    return ((mv, proof), tree)
-
--- | The implementation of lookup.
-lookupZ :: Retrieves h k v m => k -> Zipped h k v m (Maybe v)
-lookupZ k = do
+lookup k tree0 = (assoc <$>) $ runZipped UpdateMode tree0 $ do
     goto (Plain k)
     withLocus $ \case
         MLLeaf {_mlKey, _mlValue} -> do
@@ -50,3 +36,5 @@ lookupZ k = do
         
         _ -> do 
             error $ "lookup: `goto ended in non-terminal node"
+  where
+    assoc (mv, tree, trails) = ((mv, trails), tree)

--- a/src/Data/Tree/AVL/Store/Void.hs
+++ b/src/Data/Tree/AVL/Store/Void.hs
@@ -17,16 +17,17 @@ import Data.Tree.AVL.Internal
 newtype StoreT m a = StoreT { runStoreT :: m a }
     deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch, MonadMask)
 
-instance MonadTrans StoreT where
-    lift = StoreT
-
 -- | This "storage" always throws when you try to read from it.
 --   It does this, because on light client you haven't any storage,
 --   (all you have is a tree from proof).
 --
 --   So, if operations to be proven require you to read from storage,
 --   its an error (namely, 'NotFound').
-instance (Show k, Typeable k, MonadCatch m, MonadIO m) => KVRetrieve k n (StoreT m) where
+instance {-# OVERLAPPING #-}
+    (Show k, Typeable k, MonadCatch m, MonadIO m)
+  =>
+    KVRetrieve k n (StoreT m)
+  where
     retrieve k = throwM (NotFound k)
 
 -- | Storage monad that fails on any access attempt.

--- a/src/Data/Tree/AVL/Zipper.hs
+++ b/src/Data/Tree/AVL/Zipper.hs
@@ -25,27 +25,26 @@ module Data.Tree.AVL.Zipper
     , withLocus
     , change
     , replaceWith
-    , mark
+    , markHere
 
       -- * Current point iterator is standing on
     , locus
+    , setLocus
 
       -- * Debug
-    , say
-    , dump
+    -- , say
+    -- , dump
     )
   where
 
-import Control.Exception (Exception, SomeException)
-import Lens.Micro.Platform (Lens', SimpleGetter, makeLenses, use, (%=), (.=), (<&>))
+import Lens.Micro.Platform (makeLenses, use, to, (%=), _1, _2, (.~))
 
 import Control.Monad (unless, when)
 import Control.Monad.Catch (catch, throwM)
-import Control.Monad.State.Strict (StateT, evalStateT, lift, MonadIO (liftIO))
+import Control.Monad.State.Strict
 
 import Data.Monoid ((<>))
 import Data.Set (Set)
-import Data.Typeable (Typeable)
 
 import Data.Tree.AVL.Internal
 import Data.Tree.AVL.Proof
@@ -53,94 +52,49 @@ import Data.Tree.AVL.Prune
 
 import qualified Data.Set as Set (empty, fromList, insert)
 
--- | Zipper representation.
---
---   Notice that in no case can zipper modify the tree.
---   It will only create a new one with updates applied.
---
---   Zipper is pair of _locus_ and _context stack_.
---   'locus' is a place we're currently standing on.
---   Context stack is all the layers we have descent through to reach
---   where we are now.
---
---   Initially, the 'locus' is root node, and the context stack is empty.
---
---   After 'descent L' the 'locus' points to left branch of the root, and
---   the context stack will contain one layer of 'TreeZipperCtx', containing
---   data to return onto root node and update it if needed.
---
---   Zipper is also a functional iterator.
---
-data TreeZipper h k v = TreeZipper
-    { _tzContext  :: [TreeZipperCtx h k v]  -- ^ Layers above us
-    , _tzHere     ::  Map h k v             -- ^ Current point
-    , _tzKeyRange :: (Range k)              -- ^ Range of keys covered by locus
-    , _tzMode     ::  Mode                  -- ^ Update or delete
-    , _tzTouched  ::  Set h                 -- ^ Set of nodes we touched
-    , _tzDirty    ::  Bool
+import Control.Zipp as Zipp
+
+type WithTracking k h m = StateT (Context k h) m
+
+data Context k h = Context
+    { _cTouched  :: Set h
+    , _cMode     :: Mode
     }
+
+data Mode = UpdateMode | DeleteMode
 
 type Range k = (WithBounds k, WithBounds k)
 
--- | Tree layers.
-data TreeZipperCtx h k v = TreeZipperCtx
-    { _tzcSize  :: Side       -- ^ the direction we came from
-    , _tzcFrom  :: Map h k v  -- ^ the node we came from (parent)
-    , _tzcRange :: Range k    -- ^ the key range we were at
-    , _tzcDirty :: Bool
-    }
-    deriving Show
+makeLenses ''Context
 
--- | Modes of operation.
---
---   The reason for this type to exist is that rebalancer will confuse
---   situations where tree was enlarged by one operation and shrinked by another.
---
---   That is because tree only stores difference between heights of siblings
---   - 'Tilt' - so we can omit their materialisation in rebalance.
-data Mode
-    = UpdateMode    -- ^ The tree should only grow in that mode
-    | DeleteMode    -- ^ The tree should only shrink in that mode
-    | ReadonlyMode  -- ^ The tree cannot be updated at all
-    deriving (Show, Eq)
+-- instance
+--     ( Monad m
+--     , KVRetrieve h (Isolated h k v) m
+--     , MonadTrans t
+--     , Monad (t m)
+--     )
+--   =>
+--     KVRetrieve h (Isolated h k v) (t m)
+--   where
+--     retrieve = lift . retrieve
 
-makeLenses ''TreeZipper
+type Zipped h k v m = Zipp.Action Side (Map h k v, Range k) (WithTracking k h m)
 
--- | Current subtree.
-locus    :: Lens'  (TreeZipper h k v) (Map h k v)
-context  :: Lens'  (TreeZipper h k v) [TreeZipperCtx h k v]
-keyRange :: Lens'  (TreeZipper h k v) (Range k)
-trail    :: Lens'  (TreeZipper h k v) (Set h)
-mode     :: SimpleGetter (TreeZipper h k v)  Mode
+locus :: Retrieves h k v m => Zipped h k v m (Map h k v)
+locus = peek _1
 
-mode     = tzMode
-keyRange = tzKeyRange
-locus    = tzHere
-context  = tzContext
-trail    = tzTouched
-
--- | Monad, carrying zipper as state.
-type Zipped h k v m = StateT (TreeZipper h k v) m
-
-instance
-    ( Monad m
-    , KVRetrieve h (Isolated h k v) m
-    )
-  =>
-    KVRetrieve h (Isolated h k v) (Zipped h k v m)
-  where
-    retrieve = lift . retrieve
+setLocus :: Retrieves h k v m => Map h k v -> Zipped h k v m ()
+setLocus tree = void $ change (_1 .~ tree)
 
 -- | Run zipper operation, collect prefabricated proofs.
 runZipped :: Retrieves h k v m => Zipped h k v m a -> Mode -> Map h k v -> m (a, Map h k v, Set h)
-runZipped action mode0 tree = do
-    action' `evalStateT` enter mode0 tree
-  where
-    action' = do
-      res    <- action
-      tree'  <- exit
-      trails <- use trail
-      return (res, tree', trails)
+runZipped action mode tree = do
+    ((a, (tree1, _)), Context {_cTouched = set}) <- with (tree, (Bottom, Top)) action `runStateT` Context
+        { _cTouched = Set.empty
+        , _cMode    = mode
+        }
+    
+    return (a, tree1, set)
 
 -- | Run zipper operation, build proof.
 runZipped' :: Retrieves h k v m => Zipped h k v m a -> Mode -> Map h k v -> m (a, Map h k v, Proof h k v)
@@ -149,279 +103,31 @@ runZipped' action mode0 tree = do
     proof              <- prune trails tree
     return (a, tree1, proof)
 
-say :: (Retrieves h k v m, MonadIO m) => String -> Zipped h k v m ()
-say = liftIO . putStrLn
-
-dump :: (Retrieves h k v m, MonadIO m) => Zipped h k v m ()
-dump = do
-    say . showMap =<< use locus
-    ctx <- use context
-    say (show $ map (rootHash . _tzcFrom) ctx)
-
--- | Materialise tree node at locus and give it to action for introspection.
---
---   Often used with lambda-case:
---
---   > withLocus $ \case { ... }
---
-withLocus :: Retrieves h k v m => (MapLayer h k v (Map h k v) -> Zipped h k v m a) -> Zipped h k v m a
-withLocus action = do
-    loc   <- use locus
-    layer <- load loc
-    action layer
-
--- | Add current node identity to the set of nodes touched.
-mark :: Retrieves h k v m => String -> Zipped h k v m ()
-mark _msg = do
-    hash <- use locus <&> rootHash
-    trail %= Set.insert hash
-
--- | Add given node identities to the set of nodes touched.
-markAll :: Retrieves h k v m => [h] -> Zipped h k v m ()
-markAll hashes = do
-    trail %= (<> Set.fromList hashes)
-
-data AlreadyOnTop = AlreadyOnTop
-    deriving (Show)
-
-instance Exception AlreadyOnTop
-
--- | Move to the parent node; update & rebalance it if required.
-up :: forall h k m v . Retrieves h k v m => Zipped h k v m Side
-up = do
-    TreeZipperCtx side tree range wasDirty <- pop context AlreadyOnTop
-    keyRange .= range   -- restore parent 'keyRange'
-
-    dirty <- use tzDirty
-    if not dirty
-    then do
-        locus   .= tree
-        tzDirty .= (dirty || wasDirty)
-
-    else do
-        load tree >>= \case
-          MLBranch {_mlLeft, _mlRight, _mlTilt} -> do
-            now    <- use locus
-            became <- case side of
-              L -> do
-                tilt' <- correctTilt _mlLeft now _mlTilt L
-                branch tilt' now _mlRight
-
-              R -> do
-                tilt' <- correctTilt _mlRight now _mlTilt R
-                branch tilt' _mlLeft now
-
-            replaceWith became
-            rebalance
-
-          _other -> do
-            throwM AlreadyOnTop
-
-    return side
-
-pop :: (Exception e, Retrieves h k v m) => Lens' (TreeZipper h k v) [a] -> e -> Zipped h k v m a
-pop lens e = do
-    list <- use lens
-    case list of
-        [] -> throwM e
-        x : xs -> do
-            lens .= xs
-            return x
-
--- | Return to the root node.
-exit :: Retrieves h k v m => Zipped h k v m (Map h k v)
-exit = uplift
-  where
-    uplift = do
-        _ <- up
-        uplift
-      `catch` \AlreadyOnTop ->
-        use locus
-
--- | Open the tree for iteration.
-enter :: Mode -> Map h k v -> TreeZipper h k v
-enter mode0 tree = TreeZipper
-    { _tzContext  = []
-    , _tzHere     = tree
-    , _tzKeyRange = (minBound, maxBound)
-    , _tzMode     = mode0
-    , _tzTouched  = Set.empty
-    , _tzDirty    = False
-    }
-
-data WentDownOnNonBranch h = WentDownOnNonBranch h
-    deriving (Show)
-
-instance (Show h, Typeable h) => Exception (WentDownOnNonBranch h)
-
-select :: Side -> a -> a -> a
-select L a _ = a
-select R _ b = b
-
--- | Move in given direction from the current node.
-descent :: forall h k v m . Retrieves h k v m => Side -> Zipped h k v m ()
-descent side = do
-    tree  <- use locus
-    range <- use keyRange
-
-    mark $ "descent " ++ show side
-
-    load tree >>= \case
-      MLBranch { _mlLeft = left, _mlRight = right, _mlCenterKey = center } -> do
-        locus    .= select side left right
-        dirty    <- use tzDirty
-        context  %= (TreeZipperCtx side tree range dirty :)
-        keyRange .= refine side range center
-        tzDirty  .= False
-
-        mark "descent L/exit"
-
-      _layer -> do
-        throwM $ WentDownOnNonBranch (rootHash tree)
-
--- | Using side and current 'centerKey', select a key subrange we end in.
-refine
-    :: Ord key
-    => Side
-    -> (WithBounds key, WithBounds key)
-    ->  key
-    -> (WithBounds key, WithBounds key)
-refine L (l, h) (Plain -> m) = (l, min m h)
-refine R (l, h) (Plain -> m) = (max m l, h)
-
--- | Correct tilt.
-correctTilt :: Retrieves h k v m => Map h k v -> Map h k v -> Tilt -> Side -> Zipped h k v m Tilt
-correctTilt was became tilt0 side = do
-    modus   <- use mode
-    deeper  <- deepened  was became
-    shorter <- shortened was became
-    let
-      -- If we inserted and tree became deeper,  increase tilt to that side.
-      -- if we deleted  and tree became shorter, decrease tilt to that side.
-      res = case modus of
-        UpdateMode | deeper  -> roll tilt0 side
-        DeleteMode | shorter -> roll tilt0 (another side)
-        _                    -> tilt0
-
-    return res
-
--- | Find if tree became deeper.
-deepened :: Retrieves h k v m => Map h k v -> Map h k v -> Zipped h k v m Bool
-deepened was became = do
-    wasLayer    <- load was
-    becameLayer <- load became
-    wasTilt     <- tilt was
-    becameTilt  <- tilt became
-
-    case (wasLayer, becameLayer) of
-      (MLLeaf   {}, MLBranch {}) -> return True
-      (MLBranch {}, MLBranch {}) -> return $
-            wasTilt      ==    M
-        &&  becameTilt `elem` [L1, R1]
-
-      _                          -> return False
-
--- | Find if tree became shorter.
-shortened :: Retrieves h k v m => Map h k v -> Map h k v -> Zipped h k v m Bool
-shortened was became = do
-    wasLayer    <- load was
-    becameLayer <- load became
-    wasTilt     <- tilt was
-    becameTilt  <- tilt became
-
-    case (wasLayer, becameLayer) of
-      (MLBranch {}, MLLeaf   {}) -> return True
-      (MLBranch {}, MLBranch {}) -> return $
-            becameTilt   ==    M
-        &&  wasTilt    `elem` [L1, R1]
-
-      _                          -> return False
-
--- | Change tilt depending on grown side.
-roll :: Tilt -> Side -> Tilt
-roll tilt0 side =
-    case side of
-      L -> tiltLeft  tilt0
-      R -> tiltRight tilt0
-
--- | Perform a zipper action upon current node, then update set its revision
---   to be a new one.
-change
-    :: Retrieves h k v m
-    => (Zipped h k v m a)
-    -> Zipped h k v m a
-change action = do
-    modus <- use mode
-    when (modus == ReadonlyMode) $ do
-        error "change: calling this in ReadonlyMode is prohibited"
-
-    mark "change" -- automatically add node the list of touched
-    res <- action
-    tzDirty .= True
-    return res
-
--- | Place new tree into the locus, update its revision.
+-- | Place new tree into the locus, UpdateMode its revision.
 replaceWith :: Retrieves h k v m => Map h k v -> Zipped h k v m ()
 replaceWith newTree = do
-    change (locus .= newTree)
+    void $ change (_1 .~ newTree)
 
--- | Fix imbalances around current locus of editation.
-rebalance :: forall h k v m . Retrieves h k v m => Zipped h k v m ()
-rebalance = do
-    tree <- use locus
-
-    let hashes |- nodeGen = nodeGen <* markAll hashes
-
-    let combine fork left right = do
-            l <- left
-            r <- right
-            fork l r
-
-    newTree <- load tree >>= \case
-      Node r1 L2 left d -> do
-        load left >>= \case
-          Node r2 L1 a b     -> [r1, r2]     |- combine (branch M)  (pure a)        (branch M  b d)
-          Node r2 M  a b     -> [r1, r2]     |- combine (branch R1) (pure a)        (branch L1 b d)
-          Node r2 R1 a right -> do
-            load right >>= \case
-              Node r3 R1 b c -> [r1, r2, r3] |- combine (branch M)  (branch L1 a b) (branch M  c d)
-              Node r3 L1 b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch R1 c d)
-              Node r3 M  b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch M  c d)
-              _              -> return tree
-
-          _ -> return tree
-
-      Node r1 R2 a right -> do
-        load right >>= \case
-          Node r2 R1 b c     -> [r1, r2]     |- combine (branch M)  (branch M  a b) (pure c)
-          Node r2 M  b c     -> [r1, r2]     |- combine (branch L1) (branch R1 a b) (pure c)
-          Node r2 L1 left d  -> do
-            load left >>= \case
-              Node r3 R1 b c -> [r1, r2, r3] |- combine (branch M)  (branch L1 a b) (branch M  c d)
-              Node r3 L1 b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch R1 c d)
-              Node r3 M  b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch M  c d)
-              _              -> return tree
-
-          _ -> return tree
-
-      _ -> return tree
-
-    replaceWith newTree
+withLocus :: Retrieves h k v m => (MapLayer h k v (Map h k v) -> Zipped h k v m a) -> Zipped h k v m a
+withLocus action = do
+    loc   <- peek _1
+    layer <- lift $ lift $ load loc
+    action layer
 
 -- | Teleport to previous key.
 gotoPrevKey :: forall h k v m . Retrieves h k v m => k -> Zipped h k v m ()
 gotoPrevKey k = do
     goto (Plain k)
-    raiseUntilFrom R `catch` \AlreadyOnTop -> return ()
-    descent L        `catch` \(WentDownOnNonBranch (_ :: h)) -> return ()
+    raiseUntilFrom R `catch` \CantGoUp    -> return ()
+    descent L        `catch` \CantGoThere -> return ()
     whilePossible $ descent R
 
 -- | Teleport to next key.
 gotoNextKey :: forall h k v m . Retrieves h k v m => k -> Zipped h k v m ()
 gotoNextKey k = do
     goto (Plain k)
-    raiseUntilFrom L `catch` \AlreadyOnTop -> return ()
-    descent R        `catch` \(WentDownOnNonBranch (_ :: h)) -> return ()
+    raiseUntilFrom L `catch` \CantGoUp    -> return ()
+    descent R        `catch` \CantGoThere -> return ()
     whilePossible $ descent L
 
 raiseUntilFrom :: Retrieves h k v m => Side -> Zipped h k v m ()
@@ -439,7 +145,7 @@ whilePossible action = aux
         possible <- do
             _ <- action
             return True
-          `catch` \(_ :: SomeException) -> do
+          `catch` \CantGoThere -> do
             return False
 
         when possible $ do
@@ -456,7 +162,7 @@ raiseUntilHaveInRange :: Retrieves h k v m => WithBounds k -> Zipped h k v m ()
 raiseUntilHaveInRange k = goUp
   where
     goUp = do
-        range <- use keyRange
+        range <- peek _2
         unless (k `isInside` range) $ do
             _ <- up
             goUp
@@ -468,11 +174,470 @@ descentOnto :: forall h k v m . Retrieves h k v m => WithBounds k -> Zipped h k 
 descentOnto key0 = continueDescent
   where
     continueDescent = do
-        loc      <- use locus
-        center   <- centerKey loc
+        loc      <- peek _1
+        center   <- lift $ lift $ centerKey loc
         if key0 >= center
             then descent R
             else descent L
         continueDescent
-      `catch` \(WentDownOnNonBranch (_ :: h)) -> do
+      `catch` \CantGoThere -> do
         return ()
+
+descent :: forall h k v m . Retrieves h k v m => Side -> Zipped h k v m ()
+descent L = go leftDir
+descent R = go rightDir
+
+markHere :: (Monad m, Ord h) => Zipped h k v m ()
+markHere = do
+    h <- peek (_1.to rootHash)
+    lift $ cTouched %= Set.insert h
+
+mark :: (Monad m, Ord h) => h -> WithTracking k h m ()
+mark h = cTouched %= Set.insert h
+
+markAll :: (Monad m, Ord h) => [h] -> WithTracking k h m ()
+markAll hs = cTouched %= (<> Set.fromList hs)
+
+leftDir :: forall h k v m . Retrieves h k v m => Direction Side (Map h k v, Range k) (WithTracking k h m)
+leftDir = Direction
+    { designation = L
+    , tearOut = \(tree, (low, _)) -> do
+        mark (rootHash tree)
+        result <- lift $ load tree >>= \case
+            MLBranch { _mlLeft } ->
+                return _mlLeft
+            _ ->
+                throwM CantGoThere
+        
+        mark (rootHash result)
+        center <- lift $ centerKey result
+        return (result, (low, center))
+
+    , jamIn = \(parentTree, range) (leftSubTree, _) -> do
+        lift (load parentTree) >>= \case
+            MLBranch {_mlLeft, _mlRight, _mlTilt} -> do
+                mode     <- use cMode
+                tilt'    <- lift $ correctTilt mode _mlLeft leftSubTree _mlTilt L
+                result   <- lift $ branch tilt' leftSubTree _mlRight
+                balanced <- rebalance result
+                return (balanced, range)
+
+            _ -> do
+                throwM CantGoUp
+    }
+
+rightDir :: forall h k v m . Retrieves h k v m => Direction Side (Map h k v, Range k) (WithTracking k h m)
+rightDir = Direction
+    { designation = R
+    , tearOut = \(tree, (_, hi)) -> do
+        mark (rootHash tree)
+        result <- lift $ load tree >>= \case
+            MLBranch { _mlRight } ->
+                return _mlRight
+            _ ->
+                throwM CantGoThere
+        
+        mark (rootHash result)
+        center <- lift $ centerKey result
+        return (result, (center, hi))
+
+    , jamIn = \(parentTree, range) (rightSubTree, _) -> do
+        lift (load parentTree) >>= \case
+            MLBranch {_mlLeft, _mlRight, _mlTilt} -> do
+                mode     <- use cMode
+                tilt'    <- lift $ correctTilt mode _mlRight rightSubTree _mlTilt R
+                result   <- lift $ branch tilt' _mlLeft rightSubTree
+                balanced <- rebalance result
+                return (balanced, range)
+
+            _ -> do
+                throwM CantGoUp
+    }
+
+correctTilt :: Retrieves h k v m => Mode -> Map h k v -> Map h k v -> Tilt -> Side -> m Tilt
+correctTilt mode was became tilt0 side = do
+    deeper  <- deepened
+    shorter <- shortened
+    let
+      -- If we inserted and tree became deeper,  increase tilt to that side.
+      -- if we deleted  and tree became shorter, decrease tilt to that side.
+      res = case mode of
+        UpdateMode | deeper  -> roll side
+        DeleteMode | shorter -> roll (another side)
+        _                    -> tilt0
+
+    return res
+  where
+    deepened = do
+        wasLayer    <- load was
+        becameLayer <- load became
+        wasTilt     <- tilt was
+        becameTilt  <- tilt became
+
+        case (wasLayer, becameLayer) of
+          (MLLeaf   {}, MLBranch {}) -> return True
+          (MLBranch {}, MLBranch {}) -> return $
+                wasTilt      ==    M
+            &&  becameTilt `elem` [L1, R1]
+
+          _                          -> return False
+
+    shortened = do
+        wasLayer    <- load was
+        becameLayer <- load became
+        wasTilt     <- tilt was
+        becameTilt  <- tilt became
+
+        case (wasLayer, becameLayer) of
+          (MLBranch {}, MLLeaf   {}) -> return True
+          (MLBranch {}, MLBranch {}) -> return $
+                becameTilt   ==    M
+            &&  wasTilt    `elem` [L1, R1]
+
+          _                          -> return False
+
+    roll side' =
+        case side' of
+          L -> tiltLeft  tilt0
+          R -> tiltRight tilt0
+
+-- | Fix imbalances around current locus of editation.
+rebalance :: forall h k v m . Retrieves h k v m => Map h k v -> WithTracking k h m (Map h k v)
+rebalance tree = do
+    let hashes |- nodeGen = nodeGen <* markAll hashes
+
+    let combine fork left right = lift $ do
+            l <- left
+            r <- right
+            fork l r
+
+    lift (load tree) >>= \case
+      Node r1 L2 left d -> do
+        lift (load left) >>= \case
+          Node r2 L1 a b     -> [r1, r2]     |- combine (branch M)  (pure a)        (branch M  b d)
+          Node r2 M  a b     -> [r1, r2]     |- combine (branch R1) (pure a)        (branch L1 b d)
+          Node r2 R1 a right -> do
+            lift (load right) >>= \case
+              Node r3 R1 b c -> [r1, r2, r3] |- combine (branch M)  (branch L1 a b) (branch M  c d)
+              Node r3 L1 b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch R1 c d)
+              Node r3 M  b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch M  c d)
+              _              -> return tree
+
+          _ -> return tree
+
+      Node r1 R2 a right -> do
+        lift (load right) >>= \case
+          Node r2 R1 b c     -> [r1, r2]     |- combine (branch M)  (branch M  a b) (pure c)
+          Node r2 M  b c     -> [r1, r2]     |- combine (branch L1) (branch R1 a b) (pure c)
+          Node r2 L1 left d  -> do
+            lift (load left) >>= \case
+              Node r3 R1 b c -> [r1, r2, r3] |- combine (branch M)  (branch L1 a b) (branch M  c d)
+              Node r3 L1 b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch R1 c d)
+              Node r3 M  b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch M  c d)
+              _              -> return tree
+
+          _ -> return tree
+
+      _ -> return tree
+
+--       _                          -> return False
+-- -- | Move to the parent node; UpdateMode & rebalance it if required.
+-- up :: forall h k m v . Retrieves h k v m => Zipped h k v m Side
+-- up = do
+--     TreeZipperCtx side tree range wasDirty <- pop context AlreadyOnTop
+--     keyRange .= range   -- restore parent 'keyRange'
+
+--     dirty <- use tzDirty
+--     if not dirty
+--     then do
+--         locus   .= tree
+--         tzDirty .= (dirty || wasDirty)
+
+--     else do
+--         load tree >>= \case
+--           MLBranch {_mlLeft, _mlRight, _mlTilt} -> do
+--             now    <- use locus
+--             became <- case side of
+--               L -> do
+--                 tilt' <- correctTilt _mlLeft now _mlTilt L
+--                 branch tilt' now _mlRight
+
+--               R -> do
+--                 tilt' <- correctTilt _mlRight now _mlTilt R
+--                 branch tilt' _mlLeft now
+
+--             replaceWith became
+--             rebalance
+
+--           _other -> do
+--             throwM AlreadyOnTop
+
+--     return side
+
+-- -- | Move in given direction from the current node.
+-- descent :: forall h k v m . Retrieves h k v m => Side -> Zipped h k v m ()
+-- descent side = do
+--     tree  <- use locus
+--     range <- use keyRange
+
+--     mark $ "descent " ++ show side
+
+--     load tree >>= \case
+--       MLBranch { _mlLeft = left, _mlRight = right, _mlCenterKey = center } -> do
+--         locus    .= select side left right
+--         dirty    <- use tzDirty
+--         context  %= (TreeZipperCtx side tree range dirty :)
+--         keyRange .= refine side range center
+--         tzDirty  .= False
+
+--         mark "descent L/exit"
+
+--       _layer -> do
+--         throwM $ WentDownOnNonBranch (rootHash tree)
+
+-- | Zipper representation.
+--
+--   Notice that in no case can zipper modify the tree.
+--   It will only create a new one with UpdateModes applied.
+--
+--   Zipper is pair of _locus_ and _context stack_.
+--   'locus' is a place we're currently standing on.
+--   Context stack is all the layers we have descent through to reach
+--   where we are now.
+--
+--   Initially, the 'locus' is root node, and the context stack is empty.
+--
+--   After 'descent L' the 'locus' points to left branch of the root, and
+--   the context stack will contain one layer of 'TreeZipperCtx', containing
+--   data to return onto root node and UpdateMode it if needed.
+--
+--   Zipper is also a functional iterator.
+--
+-- data TreeZipper h k v = TreeZipper
+--     { _tzContext  :: [TreeZipperCtx h k v]  -- ^ Layers above us
+--     , _tzHere     ::  Map h k v             -- ^ Current point
+--     , _tzKeyRange :: (Range k)              -- ^ Range of keys covered by locus
+--     , _tzMode     ::  Mode                  -- ^ UpdateMode or delete
+--     , _tzTouched  ::  Set h                 -- ^ Set of nodes we touched
+--     , _tzDirty    ::  Bool
+--     }
+
+-- type Range k = (WithBounds k, WithBounds k)
+
+-- -- | Tree layers.
+-- data TreeZipperCtx h k v = TreeZipperCtx
+--     { _tzcSize  :: Side       -- ^ the direction we came from
+--     , _tzcFrom  :: Map h k v  -- ^ the node we came from (parent)
+--     , _tzcRange :: Range k    -- ^ the key range we were at
+--     , _tzcDirty :: Bool
+--     }
+--     deriving Show
+
+-- -- | Modes of operation.
+-- --
+-- --   The reason for this type to exist is that rebalancer will confuse
+-- --   situations where tree was enlarged by one operation and shrinked by another.
+-- --
+-- --   That is because tree only stores difference between heights of siblings
+-- --   - 'Tilt' - so we can omit their materialisation in rebalance.
+-- data Mode
+--     = UpdateModeMode    -- ^ The tree should only grow in that mode
+--     | DeleteModeMode    -- ^ The tree should only shrink in that mode
+--     | ReadonlyMode  -- ^ The tree cannot be UpdateModed at all
+--     deriving (Show, Eq)
+
+-- makeLenses ''TreeZipper
+
+-- -- | Current subtree.
+-- locus    :: Lens'  (TreeZipper h k v) (Map h k v)
+-- context  :: Lens'  (TreeZipper h k v) [TreeZipperCtx h k v]
+-- keyRange :: Lens'  (TreeZipper h k v) (Range k)
+-- trail    :: Lens'  (TreeZipper h k v) (Set h)
+-- mode     :: SimpleGetter (TreeZipper h k v)  Mode
+
+-- mode     = tzMode
+-- keyRange = tzKeyRange
+-- locus    = tzHere
+-- context  = tzContext
+-- trail    = tzTouched
+
+-- -- | Monad, carrying zipper as state.
+-- type Zipped h k v m = StateT (TreeZipper h k v) m
+
+-- instance
+--     ( Monad m
+--     , KVRetrieve h (Isolated h k v) m
+--     )
+--   =>
+--     KVRetrieve h (Isolated h k v) (Zipped h k v m)
+--   where
+--     retrieve = lift . retrieve
+
+-- -- | Run zipper operation, collect prefabricated proofs.
+-- runZipped :: Retrieves h k v m => Zipped h k v m a -> Mode -> Map h k v -> m (a, Map h k v, Set h)
+-- runZipped action mode0 tree = do
+--     action' `evalStateT` enter mode0 tree
+--   where
+--     action' = do
+--       res    <- action
+--       tree'  <- exit
+--       trails <- use trail
+--       return (res, tree', trails)
+
+-- say :: (Retrieves h k v m, MonadIO m) => String -> Zipped h k v m ()
+-- say = liftIO . putStrLn
+
+-- dump :: (Retrieves h k v m, MonadIO m) => Zipped h k v m ()
+-- dump = do
+--     say . showMap =<< use locus
+--     ctx <- use context
+--     say (show $ map (rootHash . _tzcFrom) ctx)
+
+-- -- | Materialise tree node at locus and give it to action for introspection.
+-- --
+-- --   Often used with lambda-case:
+-- --
+-- --   > withLocus $ \case { ... }
+-- --
+-- withLocus :: Retrieves h k v m => (MapLayer h k v (Map h k v) -> Zipped h k v m a) -> Zipped h k v m a
+-- withLocus action = do
+--     loc   <- use locus
+--     layer <- load loc
+--     action layer
+
+-- -- | Add current node identity to the set of nodes touched.
+-- mark :: Retrieves h k v m => String -> Zipped h k v m ()
+-- mark _msg = do
+--     hash <- use locus <&> rootHash
+--     trail %= Set.insert hash
+
+-- -- | Add given node identities to the set of nodes touched.
+-- markAll :: Retrieves h k v m => [h] -> Zipped h k v m ()
+-- markAll hashes = do
+--     trail %= (<> Set.fromList hashes)
+
+-- data AlreadyOnTop = AlreadyOnTop
+--     deriving (Show)
+
+-- instance Exception AlreadyOnTop
+
+-- pop :: (Exception e, Retrieves h k v m) => Lens' (TreeZipper h k v) [a] -> e -> Zipped h k v m a
+-- pop lens e = do
+--     list <- use lens
+--     case list of
+--         [] -> throwM e
+--         x : xs -> do
+--             lens .= xs
+--             return x
+
+-- -- | Return to the root node.
+-- exit :: Retrieves h k v m => Zipped h k v m (Map h k v)
+-- exit = uplift
+--   where
+--     uplift = do
+--         _ <- up
+--         uplift
+--       `catch` \AlreadyOnTop ->
+--         use locus
+
+-- -- | Open the tree for iteration.
+-- enter :: Mode -> Map h k v -> TreeZipper h k v
+-- enter mode0 tree = TreeZipper
+--     { _tzContext  = []
+--     , _tzHere     = tree
+--     , _tzKeyRange = (minBound, maxBound)
+--     , _tzMode     = mode0
+--     , _tzTouched  = Set.empty
+--     , _tzDirty    = False
+--     }
+
+-- data WentDownOnNonBranch h = WentDownOnNonBranch h
+--     deriving (Show)
+
+-- instance (Show h, Typeable h) => Exception (WentDownOnNonBranch h)
+
+-- -- | Using side and current 'centerKey', select a key subrange we end in.
+-- refine
+--     :: Ord key
+--     => Side
+--     -> (WithBounds key, WithBounds key)
+--     ->  key
+--     -> (WithBounds key, WithBounds key)
+-- refine L (l, h) (Plain -> m) = (l, min m h)
+-- refine R (l, h) (Plain -> m) = (max m l, h)
+
+-- -- | Correct tilt.
+-- correctTilt :: Retrieves h k v m => Map h k v -> Map h k v -> Tilt -> Side -> Zipped h k v m Tilt
+-- correctTilt was became tilt0 side = do
+--     modus   <- use mode
+--     deeper  <- deepened  was became
+--     shorter <- shortened was became
+--     let
+--       -- If we inserted and tree became deeper,  increase tilt to that side.
+--       -- if we deleted  and tree became shorter, decrease tilt to that side.
+--       res = case modus of
+--         UpdateModeMode | deeper  -> roll tilt0 side
+--         DeleteModeMode | shorter -> roll tilt0 (another side)
+--         _                    -> tilt0
+
+--     return res
+
+-- -- | Perform a zipper action upon current node, then UpdateMode set its revision
+-- --   to be a new one.
+-- change
+--     :: Retrieves h k v m
+--     => (Zipped h k v m a)
+--     -> Zipped h k v m a
+-- change action = do
+--     modus <- use mode
+--     when (modus == ReadonlyMode) $ do
+--         error "change: calling this in ReadonlyMode is prohibited"
+
+--     mark "change" -- automatically add node the list of touched
+--     res <- action
+--     tzDirty .= True
+--     return res
+
+-- -- | Fix imbalances around current locus of editation.
+-- rebalance :: forall h k v m . Retrieves h k v m => Zipped h k v m ()
+-- rebalance = do
+--     tree <- use locus
+
+--     let hashes |- nodeGen = nodeGen <* markAll hashes
+
+--     let combine fork left right = do
+--             l <- left
+--             r <- right
+--             fork l r
+
+--     newTree <- load tree >>= \case
+--       Node r1 L2 left d -> do
+--         load left >>= \case
+--           Node r2 L1 a b     -> [r1, r2]     |- combine (branch M)  (pure a)        (branch M  b d)
+--           Node r2 M  a b     -> [r1, r2]     |- combine (branch R1) (pure a)        (branch L1 b d)
+--           Node r2 R1 a right -> do
+--             load right >>= \case
+--               Node r3 R1 b c -> [r1, r2, r3] |- combine (branch M)  (branch L1 a b) (branch M  c d)
+--               Node r3 L1 b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch R1 c d)
+--               Node r3 M  b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch M  c d)
+--               _              -> return tree
+
+--           _ -> return tree
+
+--       Node r1 R2 a right -> do
+--         load right >>= \case
+--           Node r2 R1 b c     -> [r1, r2]     |- combine (branch M)  (branch M  a b) (pure c)
+--           Node r2 M  b c     -> [r1, r2]     |- combine (branch L1) (branch R1 a b) (pure c)
+--           Node r2 L1 left d  -> do
+--             load left >>= \case
+--               Node r3 R1 b c -> [r1, r2, r3] |- combine (branch M)  (branch L1 a b) (branch M  c d)
+--               Node r3 L1 b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch R1 c d)
+--               Node r3 M  b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch M  c d)
+--               _              -> return tree
+
+--           _ -> return tree
+
+--       _ -> return tree
+
+--     replaceWith newTree
+

--- a/src/Data/Tree/AVL/Zipper.hs
+++ b/src/Data/Tree/AVL/Zipper.hs
@@ -37,11 +37,11 @@ module Data.Tree.AVL.Zipper
     )
   where
 
-import Lens.Micro.Platform (makeLenses, use, to, (%=), _1, _2, (.~))
+import Lens.Micro.Platform (makeLenses, use, to, (%=), (.~))
 
-import Control.Monad (unless, when)
+import Control.Monad (unless, void)
 import Control.Monad.Catch (catch, throwM)
-import Control.Monad.State.Strict
+import Control.Monad.State.Strict (StateT (runStateT), lift)
 
 import Data.Monoid ((<>))
 import Data.Set (Set)
@@ -65,34 +65,31 @@ data Mode = UpdateMode | DeleteMode
 
 type Range k = (WithBounds k, WithBounds k)
 
+type Zipped h k v m = Zipp.Action Side (Locus h k v) (WithTracking k h m)
+
+data Locus h k v = Locus
+    { _lHere  :: Map h k v
+    , _lRange :: Range k
+    }
+
 makeLenses ''Context
-
--- instance
---     ( Monad m
---     , KVRetrieve h (Isolated h k v) m
---     , MonadTrans t
---     , Monad (t m)
---     )
---   =>
---     KVRetrieve h (Isolated h k v) (t m)
---   where
---     retrieve = lift . retrieve
-
-type Zipped h k v m = Zipp.Action Side (Map h k v, Range k) (WithTracking k h m)
+makeLenses ''Locus
 
 locus :: Retrieves h k v m => Zipped h k v m (Map h k v)
-locus = peek _1
+locus = peek lHere
 
 setLocus :: Retrieves h k v m => Map h k v -> Zipped h k v m ()
-setLocus tree = void $ change (_1 .~ tree)
+setLocus tree = void $ change (lHere .~ tree)
 
 -- | Run zipper operation, collect prefabricated proofs.
 runZipped :: Retrieves h k v m => Zipped h k v m a -> Mode -> Map h k v -> m (a, Map h k v, Set h)
 runZipped action mode tree = do
-    ((a, (tree1, _)), Context {_cTouched = set}) <- with (tree, (Bottom, Top)) action `runStateT` Context
-        { _cTouched = Set.empty
-        , _cMode    = mode
-        }
+    ((a, (Locus tree1 _)), Context {_cTouched = set})
+        <- with (Locus tree (Bottom, Top)) action
+            `runStateT` Context
+                { _cTouched = Set.empty
+                , _cMode    = mode
+                }
     
     return (a, tree1, set)
 
@@ -106,11 +103,11 @@ runZipped' action mode0 tree = do
 -- | Place new tree into the locus, UpdateMode its revision.
 replaceWith :: Retrieves h k v m => Map h k v -> Zipped h k v m ()
 replaceWith newTree = do
-    void $ change (_1 .~ newTree)
+    void $ change (lHere .~ newTree)
 
 withLocus :: Retrieves h k v m => (MapLayer h k v (Map h k v) -> Zipped h k v m a) -> Zipped h k v m a
 withLocus action = do
-    loc   <- peek _1
+    loc   <- peek lHere
     layer <- lift $ lift $ load loc
     action layer
 
@@ -130,27 +127,6 @@ gotoNextKey k = do
     descent R        `catch` \CantGoThere -> return ()
     whilePossible $ descent L
 
-raiseUntilFrom :: Retrieves h k v m => Side -> Zipped h k v m ()
-raiseUntilFrom weSeek = aux
-  where
-    aux = do
-        side <- up
-        unless (side == weSeek) $ do
-            aux
-
-whilePossible :: Retrieves h k v m => Zipped h k v m a -> Zipped h k v m ()
-whilePossible action = aux
-  where
-    aux = do
-        possible <- do
-            _ <- action
-            return True
-          `catch` \CantGoThere -> do
-            return False
-
-        when possible $ do
-            aux
-
 -- | Teleport to a 'Leaf' with given key from anywhere.
 goto :: Retrieves h k v m => WithBounds k -> Zipped h k v m ()
 goto k = do
@@ -162,7 +138,7 @@ raiseUntilHaveInRange :: Retrieves h k v m => WithBounds k -> Zipped h k v m ()
 raiseUntilHaveInRange k = goUp
   where
     goUp = do
-        range <- peek _2
+        range <- peek lRange
         unless (k `isInside` range) $ do
             _ <- up
             goUp
@@ -174,7 +150,7 @@ descentOnto :: forall h k v m . Retrieves h k v m => WithBounds k -> Zipped h k 
 descentOnto key0 = continueDescent
   where
     continueDescent = do
-        loc      <- peek _1
+        loc      <- peek lHere
         center   <- lift $ lift $ centerKey loc
         if key0 >= center
             then descent R
@@ -189,7 +165,7 @@ descent R = go rightDir
 
 markHere :: (Monad m, Ord h) => Zipped h k v m ()
 markHere = do
-    h <- peek (_1.to rootHash)
+    h <- peek (lHere.to rootHash)
     lift $ cTouched %= Set.insert h
 
 mark :: (Monad m, Ord h) => h -> WithTracking k h m ()
@@ -198,10 +174,10 @@ mark h = cTouched %= Set.insert h
 markAll :: (Monad m, Ord h) => [h] -> WithTracking k h m ()
 markAll hs = cTouched %= (<> Set.fromList hs)
 
-leftDir :: forall h k v m . Retrieves h k v m => Direction Side (Map h k v, Range k) (WithTracking k h m)
+leftDir :: forall h k v m . Retrieves h k v m => Direction Side (Locus h k v) (WithTracking k h m)
 leftDir = Direction
     { designation = L
-    , tearOut = \(tree, (low, _)) -> do
+    , tearOut = \(Locus tree (low, _)) -> do
         mark (rootHash tree)
         result <- lift $ load tree >>= \case
             MLBranch { _mlLeft } ->
@@ -211,25 +187,25 @@ leftDir = Direction
         
         mark (rootHash result)
         center <- lift $ centerKey result
-        return (result, (low, center))
+        return (Locus result (low, center))
 
-    , jamIn = \(parentTree, range) (leftSubTree, _) -> do
+    , jamIn = \(Locus parentTree range) (Locus leftSubTree _) -> do
         lift (load parentTree) >>= \case
             MLBranch {_mlLeft, _mlRight, _mlTilt} -> do
                 mode     <- use cMode
                 tilt'    <- lift $ correctTilt mode _mlLeft leftSubTree _mlTilt L
                 result   <- lift $ branch tilt' leftSubTree _mlRight
                 balanced <- rebalance result
-                return (balanced, range)
+                return (Locus balanced range)
 
             _ -> do
                 throwM CantGoUp
     }
 
-rightDir :: forall h k v m . Retrieves h k v m => Direction Side (Map h k v, Range k) (WithTracking k h m)
+rightDir :: forall h k v m . Retrieves h k v m => Direction Side (Locus h k v) (WithTracking k h m)
 rightDir = Direction
     { designation = R
-    , tearOut = \(tree, (_, hi)) -> do
+    , tearOut = \(Locus tree (_, hi)) -> do
         mark (rootHash tree)
         result <- lift $ load tree >>= \case
             MLBranch { _mlRight } ->
@@ -239,16 +215,16 @@ rightDir = Direction
         
         mark (rootHash result)
         center <- lift $ centerKey result
-        return (result, (center, hi))
+        return (Locus result (center, hi))
 
-    , jamIn = \(parentTree, range) (rightSubTree, _) -> do
+    , jamIn = \(Locus parentTree range) (Locus rightSubTree _) -> do
         lift (load parentTree) >>= \case
             MLBranch {_mlLeft, _mlRight, _mlTilt} -> do
                 mode     <- use cMode
                 tilt'    <- lift $ correctTilt mode _mlRight rightSubTree _mlTilt R
                 result   <- lift $ branch tilt' _mlLeft rightSubTree
                 balanced <- rebalance result
-                return (balanced, range)
+                return (Locus balanced range)
 
             _ -> do
                 throwM CantGoUp
@@ -339,305 +315,3 @@ rebalance tree = do
           _ -> return tree
 
       _ -> return tree
-
---       _                          -> return False
--- -- | Move to the parent node; UpdateMode & rebalance it if required.
--- up :: forall h k m v . Retrieves h k v m => Zipped h k v m Side
--- up = do
---     TreeZipperCtx side tree range wasDirty <- pop context AlreadyOnTop
---     keyRange .= range   -- restore parent 'keyRange'
-
---     dirty <- use tzDirty
---     if not dirty
---     then do
---         locus   .= tree
---         tzDirty .= (dirty || wasDirty)
-
---     else do
---         load tree >>= \case
---           MLBranch {_mlLeft, _mlRight, _mlTilt} -> do
---             now    <- use locus
---             became <- case side of
---               L -> do
---                 tilt' <- correctTilt _mlLeft now _mlTilt L
---                 branch tilt' now _mlRight
-
---               R -> do
---                 tilt' <- correctTilt _mlRight now _mlTilt R
---                 branch tilt' _mlLeft now
-
---             replaceWith became
---             rebalance
-
---           _other -> do
---             throwM AlreadyOnTop
-
---     return side
-
--- -- | Move in given direction from the current node.
--- descent :: forall h k v m . Retrieves h k v m => Side -> Zipped h k v m ()
--- descent side = do
---     tree  <- use locus
---     range <- use keyRange
-
---     mark $ "descent " ++ show side
-
---     load tree >>= \case
---       MLBranch { _mlLeft = left, _mlRight = right, _mlCenterKey = center } -> do
---         locus    .= select side left right
---         dirty    <- use tzDirty
---         context  %= (TreeZipperCtx side tree range dirty :)
---         keyRange .= refine side range center
---         tzDirty  .= False
-
---         mark "descent L/exit"
-
---       _layer -> do
---         throwM $ WentDownOnNonBranch (rootHash tree)
-
--- | Zipper representation.
---
---   Notice that in no case can zipper modify the tree.
---   It will only create a new one with UpdateModes applied.
---
---   Zipper is pair of _locus_ and _context stack_.
---   'locus' is a place we're currently standing on.
---   Context stack is all the layers we have descent through to reach
---   where we are now.
---
---   Initially, the 'locus' is root node, and the context stack is empty.
---
---   After 'descent L' the 'locus' points to left branch of the root, and
---   the context stack will contain one layer of 'TreeZipperCtx', containing
---   data to return onto root node and UpdateMode it if needed.
---
---   Zipper is also a functional iterator.
---
--- data TreeZipper h k v = TreeZipper
---     { _tzContext  :: [TreeZipperCtx h k v]  -- ^ Layers above us
---     , _tzHere     ::  Map h k v             -- ^ Current point
---     , _tzKeyRange :: (Range k)              -- ^ Range of keys covered by locus
---     , _tzMode     ::  Mode                  -- ^ UpdateMode or delete
---     , _tzTouched  ::  Set h                 -- ^ Set of nodes we touched
---     , _tzDirty    ::  Bool
---     }
-
--- type Range k = (WithBounds k, WithBounds k)
-
--- -- | Tree layers.
--- data TreeZipperCtx h k v = TreeZipperCtx
---     { _tzcSize  :: Side       -- ^ the direction we came from
---     , _tzcFrom  :: Map h k v  -- ^ the node we came from (parent)
---     , _tzcRange :: Range k    -- ^ the key range we were at
---     , _tzcDirty :: Bool
---     }
---     deriving Show
-
--- -- | Modes of operation.
--- --
--- --   The reason for this type to exist is that rebalancer will confuse
--- --   situations where tree was enlarged by one operation and shrinked by another.
--- --
--- --   That is because tree only stores difference between heights of siblings
--- --   - 'Tilt' - so we can omit their materialisation in rebalance.
--- data Mode
---     = UpdateModeMode    -- ^ The tree should only grow in that mode
---     | DeleteModeMode    -- ^ The tree should only shrink in that mode
---     | ReadonlyMode  -- ^ The tree cannot be UpdateModed at all
---     deriving (Show, Eq)
-
--- makeLenses ''TreeZipper
-
--- -- | Current subtree.
--- locus    :: Lens'  (TreeZipper h k v) (Map h k v)
--- context  :: Lens'  (TreeZipper h k v) [TreeZipperCtx h k v]
--- keyRange :: Lens'  (TreeZipper h k v) (Range k)
--- trail    :: Lens'  (TreeZipper h k v) (Set h)
--- mode     :: SimpleGetter (TreeZipper h k v)  Mode
-
--- mode     = tzMode
--- keyRange = tzKeyRange
--- locus    = tzHere
--- context  = tzContext
--- trail    = tzTouched
-
--- -- | Monad, carrying zipper as state.
--- type Zipped h k v m = StateT (TreeZipper h k v) m
-
--- instance
---     ( Monad m
---     , KVRetrieve h (Isolated h k v) m
---     )
---   =>
---     KVRetrieve h (Isolated h k v) (Zipped h k v m)
---   where
---     retrieve = lift . retrieve
-
--- -- | Run zipper operation, collect prefabricated proofs.
--- runZipped :: Retrieves h k v m => Zipped h k v m a -> Mode -> Map h k v -> m (a, Map h k v, Set h)
--- runZipped action mode0 tree = do
---     action' `evalStateT` enter mode0 tree
---   where
---     action' = do
---       res    <- action
---       tree'  <- exit
---       trails <- use trail
---       return (res, tree', trails)
-
--- say :: (Retrieves h k v m, MonadIO m) => String -> Zipped h k v m ()
--- say = liftIO . putStrLn
-
--- dump :: (Retrieves h k v m, MonadIO m) => Zipped h k v m ()
--- dump = do
---     say . showMap =<< use locus
---     ctx <- use context
---     say (show $ map (rootHash . _tzcFrom) ctx)
-
--- -- | Materialise tree node at locus and give it to action for introspection.
--- --
--- --   Often used with lambda-case:
--- --
--- --   > withLocus $ \case { ... }
--- --
--- withLocus :: Retrieves h k v m => (MapLayer h k v (Map h k v) -> Zipped h k v m a) -> Zipped h k v m a
--- withLocus action = do
---     loc   <- use locus
---     layer <- load loc
---     action layer
-
--- -- | Add current node identity to the set of nodes touched.
--- mark :: Retrieves h k v m => String -> Zipped h k v m ()
--- mark _msg = do
---     hash <- use locus <&> rootHash
---     trail %= Set.insert hash
-
--- -- | Add given node identities to the set of nodes touched.
--- markAll :: Retrieves h k v m => [h] -> Zipped h k v m ()
--- markAll hashes = do
---     trail %= (<> Set.fromList hashes)
-
--- data AlreadyOnTop = AlreadyOnTop
---     deriving (Show)
-
--- instance Exception AlreadyOnTop
-
--- pop :: (Exception e, Retrieves h k v m) => Lens' (TreeZipper h k v) [a] -> e -> Zipped h k v m a
--- pop lens e = do
---     list <- use lens
---     case list of
---         [] -> throwM e
---         x : xs -> do
---             lens .= xs
---             return x
-
--- -- | Return to the root node.
--- exit :: Retrieves h k v m => Zipped h k v m (Map h k v)
--- exit = uplift
---   where
---     uplift = do
---         _ <- up
---         uplift
---       `catch` \AlreadyOnTop ->
---         use locus
-
--- -- | Open the tree for iteration.
--- enter :: Mode -> Map h k v -> TreeZipper h k v
--- enter mode0 tree = TreeZipper
---     { _tzContext  = []
---     , _tzHere     = tree
---     , _tzKeyRange = (minBound, maxBound)
---     , _tzMode     = mode0
---     , _tzTouched  = Set.empty
---     , _tzDirty    = False
---     }
-
--- data WentDownOnNonBranch h = WentDownOnNonBranch h
---     deriving (Show)
-
--- instance (Show h, Typeable h) => Exception (WentDownOnNonBranch h)
-
--- -- | Using side and current 'centerKey', select a key subrange we end in.
--- refine
---     :: Ord key
---     => Side
---     -> (WithBounds key, WithBounds key)
---     ->  key
---     -> (WithBounds key, WithBounds key)
--- refine L (l, h) (Plain -> m) = (l, min m h)
--- refine R (l, h) (Plain -> m) = (max m l, h)
-
--- -- | Correct tilt.
--- correctTilt :: Retrieves h k v m => Map h k v -> Map h k v -> Tilt -> Side -> Zipped h k v m Tilt
--- correctTilt was became tilt0 side = do
---     modus   <- use mode
---     deeper  <- deepened  was became
---     shorter <- shortened was became
---     let
---       -- If we inserted and tree became deeper,  increase tilt to that side.
---       -- if we deleted  and tree became shorter, decrease tilt to that side.
---       res = case modus of
---         UpdateModeMode | deeper  -> roll tilt0 side
---         DeleteModeMode | shorter -> roll tilt0 (another side)
---         _                    -> tilt0
-
---     return res
-
--- -- | Perform a zipper action upon current node, then UpdateMode set its revision
--- --   to be a new one.
--- change
---     :: Retrieves h k v m
---     => (Zipped h k v m a)
---     -> Zipped h k v m a
--- change action = do
---     modus <- use mode
---     when (modus == ReadonlyMode) $ do
---         error "change: calling this in ReadonlyMode is prohibited"
-
---     mark "change" -- automatically add node the list of touched
---     res <- action
---     tzDirty .= True
---     return res
-
--- -- | Fix imbalances around current locus of editation.
--- rebalance :: forall h k v m . Retrieves h k v m => Zipped h k v m ()
--- rebalance = do
---     tree <- use locus
-
---     let hashes |- nodeGen = nodeGen <* markAll hashes
-
---     let combine fork left right = do
---             l <- left
---             r <- right
---             fork l r
-
---     newTree <- load tree >>= \case
---       Node r1 L2 left d -> do
---         load left >>= \case
---           Node r2 L1 a b     -> [r1, r2]     |- combine (branch M)  (pure a)        (branch M  b d)
---           Node r2 M  a b     -> [r1, r2]     |- combine (branch R1) (pure a)        (branch L1 b d)
---           Node r2 R1 a right -> do
---             load right >>= \case
---               Node r3 R1 b c -> [r1, r2, r3] |- combine (branch M)  (branch L1 a b) (branch M  c d)
---               Node r3 L1 b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch R1 c d)
---               Node r3 M  b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch M  c d)
---               _              -> return tree
-
---           _ -> return tree
-
---       Node r1 R2 a right -> do
---         load right >>= \case
---           Node r2 R1 b c     -> [r1, r2]     |- combine (branch M)  (branch M  a b) (pure c)
---           Node r2 M  b c     -> [r1, r2]     |- combine (branch L1) (branch R1 a b) (pure c)
---           Node r2 L1 left d  -> do
---             load left >>= \case
---               Node r3 R1 b c -> [r1, r2, r3] |- combine (branch M)  (branch L1 a b) (branch M  c d)
---               Node r3 L1 b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch R1 c d)
---               Node r3 M  b c -> [r1, r2, r3] |- combine (branch M)  (branch M  a b) (branch M  c d)
---               _              -> return tree
-
---           _ -> return tree
-
---       _ -> return tree
-
---     replaceWith newTree
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,9 +4,5 @@ packages:
 - '.'
 
 extra-deps:
-- universum-1.1.0
 - git: git@github.com:Heimdell/zipp.git
   commit: 7bf77875305c4b1930b024e21aa6691387c156fc
-
-nix:
-    packages: [rocksdb]

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,5 @@ packages:
 - '.'
 
 extra-deps:
-- git: git@github.com:Heimdell/zipp.git
+- git: git@github.com:serokell/zipp.git
   commit: 7bf77875305c4b1930b024e21aa6691387c156fc

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ packages:
 extra-deps:
 - universum-1.1.0
 - git: git@github.com:Heimdell/zipp.git
-  commit: b958ea3dd3c5ee39ce45f69a5647ba1560844280
+  commit: d484d1c6955f64073996a381d2300a6604f452d3
 
 nix:
     packages: [rocksdb]

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,8 @@ packages:
 
 extra-deps:
 - universum-1.1.0
+- git: git@github.com:Heimdell/zipp.git
+  commit: dabbdeaae6df8e788ce8938a58ce1838c4e87217
 
 nix:
     packages: [rocksdb]

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ packages:
 extra-deps:
 - universum-1.1.0
 - git: git@github.com:Heimdell/zipp.git
-  commit: d484d1c6955f64073996a381d2300a6604f452d3
+  commit: 7bf77875305c4b1930b024e21aa6691387c156fc
 
 nix:
     packages: [rocksdb]

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ packages:
 extra-deps:
 - universum-1.1.0
 - git: git@github.com:Heimdell/zipp.git
-  commit: dabbdeaae6df8e788ce8938a58ce1838c4e87217
+  commit: b958ea3dd3c5ee39ce45f69a5647ba1560844280
 
 nix:
     packages: [rocksdb]

--- a/test/Deletion.hs
+++ b/test/Deletion.hs
@@ -32,24 +32,18 @@ tests = describe "Delete" $ do
             || diff == []  && k `notElem` map fst list
 
     describe "Proofs" $ do
-        it' "Delete proof is verifiable" $ \(k, v, list) -> do
-            tree        <- AVL.fromList ((k, v) : list) :: StorageMonad M
-            (proof,  _) <- AVL.delete' k tree
-            (proof1, _) <- AVL.delete' k (AVL.unProof proof)
-            return $ AVL.checkProof (AVL.rootHash tree) proof1
+        it' "Delete proof is verifiable" $ \(k, list) -> do
+            tree      <- AVL.fromList list :: StorageMonad M
+            (set,  _) <- AVL.delete k tree
+            (set1, _) <- AVL.delete k . AVL.unProof =<< AVL.prune set tree
+            AVL.checkProof (AVL.rootHash tree) <$> AVL.prune set1 tree
 
-        it' "Delete proof is replayable" $ \(k, v, list) -> do
-            tree        <- AVL.fromList ((k, v) : list) :: StorageMonad M
+        it' "Delete proof is replayable" $ \(k, list) -> do
+            tree        <- AVL.fromList list :: StorageMonad M
             (proof1, _) <- AVL.delete k tree
             (proof2, _) <- AVL.delete k . AVL.unProof =<< AVL.prune proof1 tree
             return (proof1 == proof2)
                 :: StorageMonad Bool
-
-        it' "Delete proof is verifiable (even if there's nothing to delete)" $ \(k, list) -> do
-            tree        <- AVL.fromList list :: StorageMonad M
-            (proof,  _) <- AVL.delete' k tree
-            (proof1, _) <- AVL.delete' k (AVL.unProof proof)
-            return $ AVL.checkProof (AVL.rootHash tree) proof1
 
         it' "Delete is idempotent" $ \(k, list) -> do
             tree       <- AVL.fromList list :: StorageMonad M

--- a/test/Deletion.hs
+++ b/test/Deletion.hs
@@ -1,6 +1,5 @@
 module Deletion (tests) where
 
-import Data.Foldable (for_)
 import Data.Traversable (for)
 
 import Data.List ((\\), nub)
@@ -8,18 +7,14 @@ import Data.List ((\\), nub)
 import Common
 
 import qualified Data.Tree.AVL as AVL
-import qualified Data.Tree.AVL.Deletion as AVL
-import qualified Data.Tree.AVL.Internal as AVL
+import qualified Data.Tree.AVL.Internal as Internal
 
 tests :: Spec
 tests = describe "Delete" $ do
     it' "Tree is still balanced after delete" $ \list -> do
         tree  <- AVL.fromList list :: StorageMonad M
         trees <- scanM (AVL.deleteWithNoProof . fst) tree list
-        yes   <- and <$> for trees AVL.isBalancedToTheLeaves
-
-        for_ trees $ AVL.isBalancedToTheLeaves
-
+        yes   <- and <$> for trees Internal.isBalancedToTheLeaves
         return yes
 
     it' "Deletion deletes" $ \(k, v, list) -> do
@@ -34,19 +29,19 @@ tests = describe "Delete" $ do
     describe "Proofs" $ do
         it' "Delete proof is verifiable" $ \(k, list) -> do
             tree      <- AVL.fromList list :: StorageMonad M
-            (set,  _) <- AVL.delete k tree
-            (set1, _) <- AVL.delete k . AVL.unProof =<< AVL.prune set tree
+            (set0, _) <- AVL.delete k tree
+            (set1, _) <- AVL.delete k . AVL.unProof =<< AVL.prune set0 tree
             AVL.checkProof (AVL.rootHash tree) <$> AVL.prune set1 tree
 
         it' "Delete proof is replayable" $ \(k, list) -> do
-            tree        <- AVL.fromList list :: StorageMonad M
-            (proof1, _) <- AVL.delete k tree
-            (proof2, _) <- AVL.delete k . AVL.unProof =<< AVL.prune proof1 tree
-            return (proof1 == proof2)
+            tree          <- AVL.fromList list :: StorageMonad M
+            (set0, tree1) <- AVL.delete k tree
+            (set1, tree2) <- AVL.delete k . AVL.unProof =<< AVL.prune set0 tree
+            return (set0 == set1 && tree1 == tree2)
                 :: StorageMonad Bool
 
         it' "Delete is idempotent" $ \(k, list) -> do
-            tree       <- AVL.fromList list :: StorageMonad M
-            (_, tree1) <- AVL.delete k tree
-            (_, tree2) <- AVL.delete k tree1
+            tree  <- AVL.fromList list :: StorageMonad M
+            tree1 <- AVL.deleteWithNoProof k tree
+            tree2 <- AVL.deleteWithNoProof k tree1
             return (tree1 == tree2)

--- a/test/Insertion.hs
+++ b/test/Insertion.hs
@@ -3,8 +3,7 @@ module Insertion (tests) where
 import Common
 
 import qualified Data.Tree.AVL as AVL
-import qualified Data.Tree.AVL.Insertion as AVL
-import qualified Data.Tree.AVL.Internal as AVL
+import qualified Data.Tree.AVL.Internal as Internal
 
 tests :: Spec
 tests = describe "Insert" $ do
@@ -16,25 +15,25 @@ tests = describe "Insert" $ do
 
     it' "Tree is as balanced as possible" $ \list -> do
         tree <- AVL.fromList list :: StorageMonad M
-        AVL.isBalancedToTheLeaves tree
+        Internal.isBalancedToTheLeaves tree
 
     describe "Proofs" $ do
         it' "Insert proof is verifiable" $ \(k, v, list) -> do
-            tree        <- AVL.fromList list :: StorageMonad M
-            (proof,  _) <- AVL.insert' k v tree
-            (proof1, _) <- AVL.insert' k v (AVL.unProof proof)
+            tree      <- AVL.fromList list :: StorageMonad M
+            (set0, _) <- AVL.insert k v tree
+            (set1, _) <- AVL.insert k v . AVL.unProof =<< AVL.prune set0 tree
 
-            return $ AVL.checkProof (AVL.rootHash tree) proof1
+            AVL.checkProof (AVL.rootHash tree) <$> AVL.prune set1 tree
 
         it' "Insert proof is replayable" $ \(k, v, list) -> do
-            tree        <- AVL.fromList list :: StorageMonad M
-            (proof1, _) <- AVL.insert' k v tree
-            (proof2, _) <- AVL.insert' k v (AVL.unProof proof1)
+            tree          <- AVL.fromList list :: StorageMonad M
+            (set0, tree1) <- AVL.insert k v tree
+            (set1, tree2) <- AVL.insert k v . AVL.unProof =<< AVL.prune set0 tree
 
-            return (proof1 == proof2)
+            return (set0 == set1 && tree1 == tree2)
 
         it' "Insert is idempotent" $ \(k, v, list) -> do
-            tree <- AVL.fromList list :: StorageMonad M
-            (_, tree1) <- AVL.insert' k v tree
-            (_, tree2) <- AVL.insert' k v tree1
+            tree  <- AVL.fromList list :: StorageMonad M
+            tree1 <- AVL.insertWithNoProof k v tree
+            tree2 <- AVL.insertWithNoProof k v tree1
             return (tree1 == tree2)

--- a/test/Lookup.hs
+++ b/test/Lookup.hs
@@ -1,5 +1,8 @@
 module Lookup (tests) where
 
+import Data.Map as Map (fromList)
+import Data.Set as Set (member)
+
 import Common
 
 import qualified Data.Tree.AVL as AVL
@@ -16,6 +19,14 @@ tests = describe "Lookup" $ do
             ((Just v1, _), _) <- AVL.lookup k tree
 
             return (v == v1)
+
+    it' "LookupMany actually works" $ \(ks, list) -> do
+        tree                <- AVL.fromList list :: StorageMonad M
+        ((selection, _), _) <- AVL.lookupMany ks tree
+
+        let lookupMany =  Map.fromList . filter ((`Set.member` ks) . fst)
+
+        return (selection == lookupMany list)
 
     describe "Proofs" $ do
         it' "Generated proofs are verified" $ \(k, list) -> do

--- a/test/Lookup.hs
+++ b/test/Lookup.hs
@@ -3,7 +3,6 @@ module Lookup (tests) where
 import Common
 
 import qualified Data.Tree.AVL as AVL
-import qualified Data.Tree.AVL.Lookup as AVL
 
 tests :: Spec
 tests = describe "Lookup" $ do
@@ -20,19 +19,15 @@ tests = describe "Lookup" $ do
 
     describe "Proofs" $ do
         it' "Generated proofs are verified" $ \(k, list) -> do
-            tree            <- AVL.fromList list :: StorageMonad M
-            ((_, proof), _) <- AVL.lookup' k tree
+            tree           <- AVL.fromList list :: StorageMonad M
+            ((_, set0), _) <- AVL.lookup k tree
 
-            return $ AVL.checkProof (AVL.rootHash tree) proof
+            AVL.checkProof (AVL.rootHash tree) <$> AVL.prune set0 tree
 
         it' "Generated proofs are replayable" $ \(k, list) -> do
             tree              <- AVL.fromList list :: StorageMonad M
-            ((res, proof), _) <- AVL.lookup' k tree
+            ((res,  set0), _) <- AVL.lookup k tree
+            ((res1, set1), _) <- AVL.lookup k . AVL.unProof =<< AVL.prune set0 tree
 
-            let AVL.Proof subtree = proof
-
-            ((res1, proof1), _) <- AVL.lookup' k subtree
-
-            return $ AVL.checkProof (AVL.rootHash tree) proof
-                  && res   == res1
-                  && proof == proof1
+            return $ res   == res1
+                  && set0  == set1


### PR DESCRIPTION
These were used in tests; now tests use actual public API and `Data.Tree.AVL.Internal.isBalancedToTheLeaves`.

Also, removed excessive tests (doing the same thing as another test).