### PR TITLE
[PR-171] Removed `unpack` parameter from `prove`/`rollback`

### DIFF
--- a/test/Adapter.hs
+++ b/test/Adapter.hs
@@ -47,7 +47,7 @@ tests = describe "Adapter" do
 
             Base.append save
 
-            AVL.prove tx AVL.unpackServer \() -> AVL.insert k v
+            AVL.prove tx \() -> AVL.insert k v
 
             return True
 
@@ -61,7 +61,7 @@ tests = describe "Adapter" do
 
             ~(Left AVL.EndHashMismatch) <-
                 AVL.transact @AVL.EndHashMismatch do
-                    AVL.prove tx AVL.unpackClient \() -> do
+                    AVL.prove tx \() -> do
                         AVL.insert k (v + 1)
 
             return True
@@ -73,7 +73,7 @@ tests = describe "Adapter" do
             old      <- Base.currentRoot
             ((), tx) <- AVL.proven () \() -> AVL.insert k v
 
-            AVL.rollback tx AVL.unpackClient \() -> AVL.insert k v
+            AVL.rollback tx \() -> AVL.insert k v
 
             back <- Base.currentRoot
 
@@ -86,7 +86,7 @@ tests = describe "Adapter" do
             new       <- Base.currentRoot
 
             ~(Left _) <- AVL.transact @(Base.NotFound StringName) do
-                AVL.rollback tx AVL.unpackClient \() -> do
+                AVL.rollback tx \() -> do
                     AVL.insert k v
                     throwM $ Base.NotFound k
 

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -26,6 +26,7 @@ import Test.QuickCheck as T (Arbitrary (..), Gen, Property, Testable, elements, 
 import Test.QuickCheck.Instances as T ()
 
 import qualified Data.Tree.AVL as AVL
+import qualified Data.Tree.AVL.Adapter as Adapter
 import qualified Data.Tree.AVL.Store.Pure as Pure
 import qualified Data.Tree.AVL.Store.Void as Void
 
@@ -94,6 +95,9 @@ unique = nubBy  ((==) `on` fst)
 
 uniqued :: Ord a => [(a, b)] -> [(a, b)]
 uniqued = sortBy (comparing fst) . unique . reverse
+
+instance Adapter.CanUnwrapProof IntHash StringName Int StorageMonad' where
+    unwrapProof = Adapter.unpackOnClient
 
 it'
     ::  ( Testable (f Property)


### PR DESCRIPTION
Simplification of `Adapter` interface. The proof unwrapping it delegated to underlying monad instead of manual selection.